### PR TITLE
Fix wrong long year format causing yearyear - misleading ui.datepicker d...

### DIFF
--- a/application/models/Settings.php
+++ b/application/models/Settings.php
@@ -235,13 +235,13 @@ class Settings extends BaseSettings {
 	public static function getDateFormat() {
 	    $date = Zend_Date::now();
 	    
-	    $dateformat['%d/%m/%Y|dd/MM/YYYY|dd/mm/yyyy'] = 'dd/MM/YYYY - (' . $date->toString('dd/MM/YYYY') . ")";
-	    $dateformat['%m/%d/%Y|M/d/Y|mm/dd/yy'] = 'M/d/Y - (' . $date->toString('M/d/Y') . ")";
-	    $dateformat['%Y/%m/%d|Y/M/d|yy/mm/dd'] = 'Y/M/d - (' . $date->toString('Y/M/d') . ")";
+	    $dateformat['%d/%m/%Y|dd/MM/YYYY|dd/mm/yy'] = 'dd/MM/YYYY - (' . $date->toString('dd/MM/YYYY') . ")";
+	    $dateformat['%m/%d/%Y|M/d/Y|mm/dd/y'] = 'M/d/Y - (' . $date->toString('M/d/Y') . ")";
+	    $dateformat['%Y/%m/%d|Y/M/d|y/mm/dd'] = 'Y/M/d - (' . $date->toString('Y/M/d') . ")";
 	    
-	    $dateformat['%d-%m-%Y|d-M-Y|dd-mm-yy'] = 'd-M-Y - (' . $date->toString('d-M-Y') . ")";
-	    $dateformat['%m-%d-%Y|M-d-Y|mm-dd-yy'] = 'M-d-Y - (' . $date->toString('M-d-Y') . ")";
-	    $dateformat['%Y-%m-%d|Y-M-d|yy-mm-dd'] = 'Y-M-d - (' . $date->toString('Y-M-d') . ")";
+	    $dateformat['%d-%m-%Y|d-M-Y|dd-mm-y'] = 'd-M-Y - (' . $date->toString('d-M-Y') . ")";
+	    $dateformat['%m-%d-%Y|M-d-Y|mm-dd-y'] = 'M-d-Y - (' . $date->toString('M-d-Y') . ")";
+	    $dateformat['%Y-%m-%d|Y-M-d|y-mm-dd'] = 'Y-M-d - (' . $date->toString('Y-M-d') . ")";
 
 		return $dateformat;
 	}


### PR DESCRIPTION
Fix wrong long year format causing yearyear - misleading ui.datepicker dateFormat

Sorry that almost every lines are marked as changed. This is due github reformating
add param w=1 at the github url to see only real changes